### PR TITLE
Reformat code, add format check

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/.github/workflows/elixir-quality-checks.yml
+++ b/.github/workflows/elixir-quality-checks.yml
@@ -28,11 +28,11 @@ jobs:
 
       - name: Check for unused deps
         run: mix deps.unlock --check-unused
-      # - name: Check code formatting
-      #   run: mix format --check-formatted
-      #   # Check formatting even if there were unused deps so that
-      #   # we give devs as much feedback as possible & save some time.
-      #   if: always()
+      - name: Check code formatting
+        run: mix format --check-formatted
+        # Check formatting even if there were unused deps so that
+        # we give devs as much feedback as possible & save some time.
+        if: always()
       # - name: Run Credo
       #   run: mix credo suggest --min-priority=normal
       #   # Run Credo even if formatting or the unused deps check failed

--- a/config/config.exs
+++ b/config/config.exs
@@ -3,10 +3,11 @@
 import Config
 
 config :forcex, :api, Forcex.Api.Http
+
 config :logger,
-  :console,
-  format: "\n$time $metadata[$level] $levelpad$message\n",
-  metadata: [:file, :line]
+       :console,
+       format: "\n$time $metadata[$level] $levelpad$message\n",
+       metadata: [:file, :line]
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this
@@ -26,4 +27,4 @@ config :logger,
 # by uncommenting the line below and defining dev.exs, test.exs and such.
 # Configuration from the imported file will override the ones defined
 # here (which is why it is important to import them last).
-import_config "#{Mix.env}.exs"
+import_config "#{Mix.env()}.exs"

--- a/lib/forcex.ex
+++ b/lib/forcex.ex
@@ -6,37 +6,37 @@ defmodule Forcex do
   require Logger
 
   @type client :: map
-  @type forcex_response :: map | {number, any} | String.t
+  @type forcex_response :: map | {number, any} | String.t()
   @type method :: :get | :put | :post | :patch | :delete
 
   def api_client, do: Application.get_env(:forcex, :api) || Forcex.Api.Http
 
-  @spec json_request(method, String.t, map | String.t, list, list) :: forcex_response
+  @spec json_request(method, String.t(), map | String.t(), list, list) :: forcex_response
   def json_request(method, url, body, headers, options) do
     api_client().raw_request(method, url, format_body(body), headers, options)
   end
 
-  @spec post(String.t, map | String.t, client) :: forcex_response
+  @spec post(String.t(), map | String.t(), client) :: forcex_response
   def post(path, body \\ "", client) do
     url = client.endpoint <> path
     headers = [{"Content-Type", "application/json"}]
     json_request(:post, url, body, headers ++ client.authorization_header, [])
   end
 
-  @spec patch(String.t, String.t, client) :: forcex_response
+  @spec patch(String.t(), String.t(), client) :: forcex_response
   def patch(path, body \\ "", client) do
     url = client.endpoint <> path
     headers = [{"Content-Type", "application/json"}]
     json_request(:patch, url, body, headers ++ client.authorization_header, [])
   end
 
-  @spec delete(String.t, client) :: forcex_response
+  @spec delete(String.t(), client) :: forcex_response
   def delete(path, client) do
     url = client.endpoint <> path
     api_client().raw_request(:delete, url, "", client.authorization_header, [])
   end
 
-  @spec get(String.t, map | String.t, list, client) :: forcex_response
+  @spec get(String.t(), map | String.t(), list, client) :: forcex_response
   def get(path, body \\ "", headers \\ [], client) do
     url = client.endpoint <> path
     json_request(:get, url, body, headers ++ client.authorization_header, [])
@@ -58,7 +58,7 @@ defmodule Forcex do
     quick_actions: :quickActions,
     recently_viewed_items: :recent,
     tabs: :tabs,
-    theme: :theme,
+    theme: :theme
   ]
 
   for {function, service} <- @basic_services do
@@ -70,7 +70,7 @@ defmodule Forcex do
     end
   end
 
-  @spec describe_sobject(String.t, client) :: forcex_response
+  @spec describe_sobject(String.t(), client) :: forcex_response
   def describe_sobject(sobject, %Forcex.Client{} = client) do
     base = service_endpoint(client, :sobjects)
 
@@ -85,7 +85,7 @@ defmodule Forcex do
     |> get(client)
   end
 
-  @spec metadata_changes_since(String.t, String.t, client) :: forcex_response
+  @spec metadata_changes_since(String.t(), String.t(), client) :: forcex_response
   def metadata_changes_since(sobject, since, client) do
     base = service_endpoint(client, :sobjects)
 
@@ -99,25 +99,25 @@ defmodule Forcex do
     |> post(body, client)
   end
 
-  @spec query(String.t, client) :: forcex_response
+  @spec query(String.t(), client) :: forcex_response
   def query(query, %Forcex.Client{} = client) do
     base = service_endpoint(client, :query)
-    params = %{"q" => query} |> URI.encode_query
+    params = %{"q" => query} |> URI.encode_query()
 
     "#{base}/?#{params}"
     |> get(client)
   end
 
-  @spec query_all(String.t, client) :: forcex_response
+  @spec query_all(String.t(), client) :: forcex_response
   def query_all(query, %Forcex.Client{} = client) do
     base = service_endpoint(client, :queryAll)
-    params = %{"q" => query} |> URI.encode_query
+    params = %{"q" => query} |> URI.encode_query()
 
     "#{base}/?#{params}"
     |> get(client)
   end
 
-  @spec service_endpoint(client, atom) :: String.t
+  @spec service_endpoint(client, atom) :: String.t()
   defp service_endpoint(%Forcex.Client{services: services}, service) do
     Map.get(services, service)
   end

--- a/lib/forcex/api.ex
+++ b/lib/forcex/api.ex
@@ -4,7 +4,7 @@ defmodule Forcex.Api do
   """
 
   @type method :: :get | :put | :post | :patch | :delete
-  @type forcex_response :: map | {number, any} | String.t
+  @type forcex_response :: map | {number, any} | String.t()
 
-  @callback raw_request(method, String.t, map | String.t, list, list) :: forcex_response
+  @callback raw_request(method, String.t(), map | String.t(), list, list) :: forcex_response
 end

--- a/lib/forcex/auth/oauth.ex
+++ b/lib/forcex/auth/oauth.ex
@@ -31,9 +31,7 @@ defmodule Forcex.Auth.OAuth do
 
   defp handle_login_response({status_code, error_message}) do
     Logger.warn(
-      "Cannot log into SFDC API. Please ensure you have Forcex properly configured. Got error code #{
-        status_code
-      } and message #{inspect(error_message)}"
+      "Cannot log into SFDC API. Please ensure you have Forcex properly configured. Got error code #{status_code} and message #{inspect(error_message)}"
     )
 
     %{}
@@ -42,6 +40,7 @@ defmodule Forcex.Auth.OAuth do
   defp maybe_add_api_version(client_map, %{api_version: api_version}) do
     Map.put(client_map, :api_version, api_version)
   end
+
   defp maybe_add_api_version(client_map, _) do
     client_map
   end

--- a/lib/forcex/auth/session_id.ex
+++ b/lib/forcex/auth/session_id.ex
@@ -37,6 +37,7 @@ defmodule Forcex.Auth.SessionId do
     url = starting_struct.endpoint <> "/services/Soap/u/#{starting_struct.api_version}"
 
     Logger.debug("api=#{api_client()}")
+
     api_client().raw_request(:post, url, body, headers, [])
     |> handle_login_response
   end

--- a/lib/forcex/bulk/batch_handler.ex
+++ b/lib/forcex/bulk/batch_handler.ex
@@ -11,19 +11,22 @@ defmodule Forcex.Bulk.BatchHandler do
       def handle_info({:batch_status, %{state: "Completed"} = batch}, state) do
         handle_batch_completed(batch, state)
       end
+
       def handle_info({:batch_status, %{state: "Failed"} = batch}, state) do
         handle_batch_failed(batch, state)
       end
+
       def handle_info({:batch_status, batch}, state) do
         handle_batch_status(batch, state)
       end
+
       def handle_info({:batch_created, batch}, state) do
         handle_batch_created(batch, state)
       end
+
       def handle_info({:batch_partial_result_ready, batch, result}, state) do
         handle_batch_partial_result_ready(batch, result, state)
       end
     end
   end
 end
-

--- a/lib/forcex/bulk/batch_worker.ex
+++ b/lib/forcex/bulk/batch_worker.ex
@@ -15,7 +15,7 @@ defmodule Forcex.Bulk.BatchWorker do
     client = Keyword.fetch!(state, :client)
     job = Keyword.fetch!(state, :job)
     query = Keyword.fetch!(state, :query)
-    handlers = Keyword.fetch!(state,:handlers)
+    handlers = Keyword.fetch!(state, :handlers)
     interval = Keyword.get(state, :status_interval, 10000)
 
     batch = Forcex.Bulk.create_query_batch(query, job, client)
@@ -39,12 +39,14 @@ defmodule Forcex.Bulk.BatchWorker do
     seen_results = Keyword.get(state, :results, [])
 
     results = Forcex.Bulk.fetch_batch_result_status(batch, client)
-    case (results -- seen_results) do
+
+    case results -- seen_results do
       list when is_list(list) ->
         for result <- list do
           notify_handlers({:batch_partial_result_ready, batch, result}, handlers)
         end
-      # _ -> true
+
+        # _ -> true
     end
 
     Keyword.put(state, :results, results)
@@ -71,5 +73,4 @@ defmodule Forcex.Bulk.BatchWorker do
       _ -> {:noreply, state}
     end
   end
-
 end

--- a/lib/forcex/bulk/job_handler.ex
+++ b/lib/forcex/bulk/job_handler.ex
@@ -10,19 +10,25 @@ defmodule Forcex.Bulk.JobHandler do
       def handle_info({:job_created, job}, state) do
         handle_job_created(job, state)
       end
+
       def handle_info({:job_status, %{state: "Closed"} = job}, state) do
         handle_job_closed(job, state)
       end
-      def handle_info({:job_status, %{numberBatchesCompleted: num, numberBatchesTotal: num} = job}, state) do
+
+      def handle_info(
+            {:job_status, %{numberBatchesCompleted: num, numberBatchesTotal: num} = job},
+            state
+          ) do
         handle_job_all_batches_complete(job, state)
       end
+
       def handle_info({:job_status, job}, state) do
         handle_job_status(job, state)
       end
+
       def handle_info({:job_closed, job}, state) do
-       handle_job_closed(job, state)
+        handle_job_closed(job, state)
       end
     end
   end
 end
-

--- a/lib/forcex/bulk/job_worker.ex
+++ b/lib/forcex/bulk/job_worker.ex
@@ -14,7 +14,7 @@ defmodule Forcex.Bulk.JobWorker do
   def handle_info(:after_init, state) do
     client = Keyword.fetch!(state, :client)
     sobject = Keyword.fetch!(state, :sobject)
-    handlers = Keyword.get(state,:handlers, [])
+    handlers = Keyword.get(state, :handlers, [])
     interval = Keyword.get(state, :status_interval, 10000)
 
     job = Forcex.Bulk.create_query_job(sobject, client)
@@ -27,7 +27,7 @@ defmodule Forcex.Bulk.JobWorker do
   def handle_info(:fetch_status, state) do
     client = Keyword.fetch!(state, :client)
     job = Keyword.fetch!(state, :job)
-    handlers = Keyword.get(state,:handlers, [])
+    handlers = Keyword.get(state, :handlers, [])
 
     updated_job = Forcex.Bulk.fetch_job_status(job, client)
 
@@ -45,5 +45,4 @@ defmodule Forcex.Bulk.JobWorker do
     notify_handlers({:job_closed, closed_job}, handlers)
     {:stop, :normal, Keyword.put(state, :job, closed_job)}
   end
-
 end

--- a/lib/forcex/client.ex
+++ b/lib/forcex/client.ex
@@ -67,9 +67,13 @@ defmodule Forcex.Client do
 
   def login(conf, starting_struct) do
     Logger.debug("conf=" <> inspect(conf))
+
     case conf do
-      %{client_id: _} -> struct(__MODULE__, Forcex.Auth.OAuth.login(conf, starting_struct))
-      %{security_token: _} -> struct(__MODULE__, Forcex.Auth.SessionId.login(conf, starting_struct))
+      %{client_id: _} ->
+        struct(__MODULE__, Forcex.Auth.OAuth.login(conf, starting_struct))
+
+      %{security_token: _} ->
+        struct(__MODULE__, Forcex.Auth.SessionId.login(conf, starting_struct))
     end
   end
 
@@ -82,7 +86,7 @@ defmodule Forcex.Client do
 
   def default_config() do
     [:username, :password, :security_token, :client_id, :client_secret, :endpoint]
-    |> Enum.map(&({&1, get_val_from_env(&1)}))
+    |> Enum.map(&{&1, get_val_from_env(&1)})
     |> Enum.filter(fn {_, v} -> v end)
     |> Enum.into(%{})
   end
@@ -90,14 +94,16 @@ defmodule Forcex.Client do
   defp get_val_from_env(key) do
     key
     |> env_var
-    |> System.get_env
+    |> System.get_env()
     |> case do
       nil ->
         Application.get_env(:forcex, __MODULE__, [])
         |> Keyword.get(key)
-      val -> val
+
+      val ->
+        val
     end
   end
 
-  defp env_var(key), do: "SALESFORCE_#{key |> to_string |> String.upcase}"
+  defp env_var(key), do: "SALESFORCE_#{key |> to_string |> String.upcase()}"
 end

--- a/lib/mix/tasks/compile.forcex.ex
+++ b/lib/mix/tasks/compile.forcex.ex
@@ -6,11 +6,14 @@ defmodule Mix.Tasks.Compile.Forcex do
   def run(_) do
     {:ok, _} = Application.ensure_all_started(:forcex)
 
-    client = Forcex.Client.login
+    client = Forcex.Client.login()
 
     case client do
-      %{access_token: nil} -> IO.puts("Invalid configuration/credentials. Cannot generate SObjects.")
-      _ -> generate_modules(client)
+      %{access_token: nil} ->
+        IO.puts("Invalid configuration/credentials. Cannot generate SObjects.")
+
+      _ ->
+        generate_modules(client)
     end
 
     :ok
@@ -21,15 +24,14 @@ defmodule Mix.Tasks.Compile.Forcex do
 
     sobjects =
       client
-      |> Forcex.describe_global
+      |> Forcex.describe_global()
       |> Map.get(:sobjects)
 
     for sobject <- sobjects do
       sobject
       |> generate_module(client)
-      |> Code.compile_quoted
+      |> Code.compile_quoted()
     end
-
   end
 
   defp generate_module(sobject, client) do
@@ -136,16 +138,20 @@ defmodule Mix.Tasks.Compile.Forcex do
 
         See [SObject Get Deleted](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_getdeleted.htm)
         """
-        def deleted_between(start_date, end_date, client) when is_binary(start_date) and is_binary(end_date) do
-          params = %{"start" => start_date, "end" => end_date} |> URI.encode_query
-          unquote(sobject_url) <> "/deleted?#{params}"
+        def deleted_between(start_date, end_date, client)
+            when is_binary(start_date) and is_binary(end_date) do
+          params = %{"start" => start_date, "end" => end_date} |> URI.encode_query()
+
+          (unquote(sobject_url) <> "/deleted?#{params}")
           |> Forcex.get(client)
         end
+
         def deleted_between(start_date, end_date, client) do
           deleted_between(
             Timex.format!(start_date, "{ISO8601z}"),
             Timex.format!(end_date, "{ISO8601z}"),
-            client)
+            client
+          )
         end
 
         @doc """
@@ -157,16 +163,20 @@ defmodule Mix.Tasks.Compile.Forcex do
 
         See [SObject Get Updated](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_getupdated.htm)
         """
-        def updated_between(start_date, end_date, client) when is_binary(start_date) and is_binary(end_date) do
-          params = %{"start" => start_date, "end" => end_date} |> URI.encode_query
-          unquote(sobject_url) <> "/updated?#{params}"
+        def updated_between(start_date, end_date, client)
+            when is_binary(start_date) and is_binary(end_date) do
+          params = %{"start" => start_date, "end" => end_date} |> URI.encode_query()
+
+          (unquote(sobject_url) <> "/updated?#{params}")
           |> Forcex.get(client)
         end
+
         def updated_between(start_date, end_date, client) do
           updated_between(
             Timex.format!(start_date, "{ISO}"),
             Timex.format!(end_date, "{ISO}"),
-            client)
+            client
+          )
         end
 
         @doc """
@@ -179,7 +189,7 @@ defmodule Mix.Tasks.Compile.Forcex do
         See [SObject Blob Retrieve](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_sobject_blob_retrieve.htm)
         """
         def get_blob(id, field, client) do
-          unquote(row_template_url) <> "/#{field}"
+          (unquote(row_template_url) <> "/#{field}")
           |> String.replace("{ID}", id)
           |> Forcex.get(client)
         end
@@ -194,27 +204,30 @@ defmodule Mix.Tasks.Compile.Forcex do
         See [SObject Rows by External ID](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_sobject_upsert.htm)
         """
         def by_external(field, value, client) do
-          unquote(sobject_url) <> "/#{field}/#{value}"
+          (unquote(sobject_url) <> "/#{field}/#{value}")
           |> Forcex.get(client)
         end
       end
-      IO.puts "Generated #{unquote(Module.concat(Forcex.SObject, name))}"
-    end
 
+      IO.puts("Generated #{unquote(Module.concat(Forcex.SObject, name))}")
+    end
   end
 
-  defp docs_for_field(%{name: name, type: type, label: label, picklistValues: values}) when type in [:picklist, :multipicklist] do
+  defp docs_for_field(%{name: name, type: type, label: label, picklistValues: values})
+       when type in [:picklist, :multipicklist] do
     """
     * `#{name}` - `#{type}`, #{label}
     #{for value <- values, do: docs_for_picklist_values(value)}
     """
   end
+
   defp docs_for_field(%{name: name, type: type, label: label}) do
     "* `#{name}` - `#{type}`, #{label}\n"
   end
 
   defp docs_for_picklist_values(%{value: value, active: true}) do
-"     * `#{value}`\n"
+    "     * `#{value}`\n"
   end
+
   defp docs_for_picklist_values(_), do: ""
 end

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule Forcex.Mixfile do
         "coveralls.html": :test,
         "coveralls.post": :test,
         docs: :dev,
-        "hex.docs": :dev,
+        "hex.docs": :dev
       ],
       dialyzer: [
         plt_add_deps: :transitive,
@@ -39,12 +39,12 @@ defmodule Forcex.Mixfile do
         plt_add_apps: [:mix]
       ],
       deps: deps(),
-      elixirc_paths: elixirc_paths(Mix.env)
-   ]
+      elixirc_paths: elixirc_paths(Mix.env())
+    ]
   end
 
   defp elixirc_paths(:test), do: ["test/support", "lib"]
-  defp elixirc_paths(_),     do: ["lib"]
+  defp elixirc_paths(_), do: ["lib"]
 
   # Configuration for the OTP application
   #
@@ -82,9 +82,11 @@ defmodule Forcex.Mixfile do
   end
 
   defp package do
-    [maintainers: ["Jeff Weiss", "Matt Robinson"],
+    [
+      maintainers: ["Jeff Weiss", "Matt Robinson"],
       licenses: ["MIT"],
-      links: %{"Github" => "https://github.com/jeffweiss/forcex"}]
+      links: %{"Github" => "https://github.com/jeffweiss/forcex"}
+    ]
   end
 
   defp aliases do

--- a/test/forcex/client_test.exs
+++ b/test/forcex/client_test.exs
@@ -24,10 +24,12 @@ defmodule Forcex.ClientTest do
 
       client = Forcex.Client.login(config)
 
-      assert client.authorization_header == [{
-        "Authorization",
-        "Bearer #{@session_id}"
-      }]
+      assert client.authorization_header == [
+               {
+                 "Authorization",
+                 "Bearer #{@session_id}"
+               }
+             ]
 
       assert client.endpoint == "https://forcex.my.salesforce.com/"
     end
@@ -66,7 +68,6 @@ defmodule Forcex.ClientTest do
 
       response = %{
         access_token: access_token,
-
         id: "https://login.salesforce.com/id/#{org_id}/005d0000001Jb9tAAC",
         instance_url: "https://forcex.my.salesforce.com",
         issued_at: "1520973086810",
@@ -86,51 +87,60 @@ defmodule Forcex.ClientTest do
         api_version: "123.0"
       }
 
-      {:ok,
-       access_token: access_token,
-       config: config
-      }
+      {:ok, access_token: access_token, config: config}
     end
 
     test "sets the auth header and endpoint when successful", %{
-      config: config, access_token: access_token
+      config: config,
+      access_token: access_token
     } do
       client = Forcex.Client.login(config)
-      assert client.authorization_header == [{
-        "Authorization",
-        "Bearer #{access_token}"
-      }]
+
+      assert client.authorization_header == [
+               {
+                 "Authorization",
+                 "Bearer #{access_token}"
+               }
+             ]
+
       assert client.endpoint == "https://forcex.my.salesforce.com"
     end
 
     test "defaults the api_version if not specified in the starting_struct", %{
-      config: config, access_token: access_token
+      config: config,
+      access_token: access_token
     } do
       client = Forcex.Client.login(config)
 
-      assert client.authorization_header == [{
-        "Authorization",
-        "Bearer #{access_token}"
-      }]
+      assert client.authorization_header == [
+               {
+                 "Authorization",
+                 "Bearer #{access_token}"
+               }
+             ]
+
       assert client.api_version == "43.0"
     end
 
     test "allows overriding the api_version as specified in the starting_struct", %{
-      config: config, access_token: access_token
+      config: config,
+      access_token: access_token
     } do
       starting_struct = %Forcex.Client{api_version: "123.0"}
       client = Forcex.Client.login(config, starting_struct)
 
-      assert client.authorization_header == [{
-        "Authorization",
-        "Bearer #{access_token}"
-      }]
+      assert client.authorization_header == [
+               {
+                 "Authorization",
+                 "Bearer #{access_token}"
+               }
+             ]
+
       assert client.api_version == "123.0"
     end
   end
 
   describe "default login behavior" do
-
     test "default endpoint provided by client struct is login.salesforce.com" do
       initial_struct = %Forcex.Client{}
       assert initial_struct.endpoint == "https://login.salesforce.com"
@@ -162,15 +172,16 @@ defmodule Forcex.ClientTest do
 
       Forcex.Api.MockHttp
       |> expect(:raw_request, fn :post, url, _, _, _ ->
-          assert String.starts_with?(url, "https://login.salesforce.com") == true
-          response
-          end)
+        assert String.starts_with?(url, "https://login.salesforce.com") == true
+        response
+      end)
 
       Forcex.Client.login(config)
     end
 
     test "when provided config with new endpoint, uses provided endpoint" do
       endpoint = "https://test.salesforce.com"
+
       config = %{
         password: "password",
         security_token: "security_token",
@@ -191,9 +202,9 @@ defmodule Forcex.ClientTest do
 
       Forcex.Api.MockHttp
       |> expect(:raw_request, fn :post, url, _, _, _ ->
-          assert String.starts_with?(url, endpoint) == true
-          response
-          end)
+        assert String.starts_with?(url, endpoint) == true
+        response
+      end)
 
       Forcex.Client.login(config)
     end
@@ -203,7 +214,7 @@ defmodule Forcex.ClientTest do
     test "when successful sets servies on the client" do
       response = %{
         jobs: "/services/data/v43.0/jobs",
-        query: "/services/data/v43.0/query",
+        query: "/services/data/v43.0/query"
       }
 
       endpoint = "https://forcex.my.salesforce.com"
@@ -212,7 +223,7 @@ defmodule Forcex.ClientTest do
       services_url = endpoint <> "/services/data/v" <> api_version
 
       Forcex.Api.MockHttp
-      |> expect(:raw_request, fn(:get, ^services_url, _, ^auth_header, _) -> response end)
+      |> expect(:raw_request, fn :get, ^services_url, _, ^auth_header, _ -> response end)
 
       client = %Forcex.Client{
         endpoint: endpoint,
@@ -220,7 +231,7 @@ defmodule Forcex.ClientTest do
         api_version: api_version
       }
 
-      client = client |> Forcex.Client.locate_services
+      client = client |> Forcex.Client.locate_services()
       assert client.services == response
     end
   end

--- a/test/forcex_test.exs
+++ b/test/forcex_test.exs
@@ -9,8 +9,22 @@ defmodule ForcexTest do
       done: false,
       nextRecordsUrl: "/services/data/v43.0/query/01g0W00006pQQsWQAW-2000",
       records: [
-        %{Id: "0010W00002JBygyQAD", Name: "Michael Weber", attributes: %{type: "Account", url: "/services/data/v43.0/sobjects/Account/0010W00002JBygyQAD"}},
-        %{Id: "0010W00002JBw2mQAD", Name: "Erica Adams", attributes: %{type: "Account", url: "/services/data/v43.0/sobjects/Account/0010W00002JBw2mQAD"}},
+        %{
+          Id: "0010W00002JBygyQAD",
+          Name: "Michael Weber",
+          attributes: %{
+            type: "Account",
+            url: "/services/data/v43.0/sobjects/Account/0010W00002JBygyQAD"
+          }
+        },
+        %{
+          Id: "0010W00002JBw2mQAD",
+          Name: "Erica Adams",
+          attributes: %{
+            type: "Account",
+            url: "/services/data/v43.0/sobjects/Account/0010W00002JBw2mQAD"
+          }
+        }
       ],
       totalSize: 5989
     }
@@ -20,18 +34,18 @@ defmodule ForcexTest do
     auth_header = [{"Authorization", "Bearer sometoken"}]
     query_path = "/services/data/v43.0/query"
     query = "select Id, Name from Account order by CreatedDate desc"
-    query_url = "#{endpoint}#{query_path}/?#{%{"q" => query} |> URI.encode_query}"
+    query_url = "#{endpoint}#{query_path}/?#{%{"q" => query} |> URI.encode_query()}"
 
     Forcex.Api.MockHttp
-    |> expect(:raw_request, fn(:get, ^query_url, _, ^auth_header, _) -> response end)
+    |> expect(:raw_request, fn :get, ^query_url, _, ^auth_header, _ -> response end)
 
-      client = %Forcex.Client{
-        endpoint: endpoint,
-        authorization_header: auth_header,
-        api_version: api_version,
-        services: %{query: query_path}
-      }
+    client = %Forcex.Client{
+      endpoint: endpoint,
+      authorization_header: auth_header,
+      api_version: api_version,
+      services: %{query: query_path}
+    }
 
-      assert Forcex.query(query, client) == response
+    assert Forcex.query(query, client) == response
   end
 end


### PR DESCRIPTION
Use `mix format` to reformat code according to elixir's standard style guide, and enable the `mix format` check in CI.