### PR TITLE
Add and enable credo

### DIFF
--- a/.github/workflows/elixir-quality-checks.yml
+++ b/.github/workflows/elixir-quality-checks.yml
@@ -33,10 +33,10 @@ jobs:
         # Check formatting even if there were unused deps so that
         # we give devs as much feedback as possible & save some time.
         if: always()
-      # - name: Run Credo
-      #   run: mix credo suggest --min-priority=normal
-      #   # Run Credo even if formatting or the unused deps check failed
-      #   if: always()
+      - name: Run Credo
+        run: mix credo suggest --min-priority=normal
+        # Run Credo even if formatting or the unused deps check failed
+        if: always()
       - name: Check for compile-time dependencies
         run: mix xref graph --label compile-connected --fail-above 0
         if: always()

--- a/lib/forcex/bulk.ex
+++ b/lib/forcex/bulk.ex
@@ -1,4 +1,8 @@
 defmodule Forcex.Bulk do
+  @moduledoc """
+  HTTP communication with the Salesforce Bulk API
+  """
+
   use HTTPoison.Base
   require Logger
 

--- a/lib/forcex/bulk/batch_handler.ex
+++ b/lib/forcex/bulk/batch_handler.ex
@@ -1,4 +1,8 @@
 defmodule Forcex.Bulk.BatchHandler do
+  @moduledoc """
+  Functions for handling bulk batch state changes.
+  """
+
   @callback handle_batch_status(map, any) :: {:noreply, any}
   @callback handle_batch_created(map, any) :: {:noreply, any}
   @callback handle_batch_completed(map, any) :: {:noreply, any}

--- a/lib/forcex/bulk/batch_worker.ex
+++ b/lib/forcex/bulk/batch_worker.ex
@@ -1,4 +1,8 @@
 defmodule Forcex.Bulk.BatchWorker do
+  @moduledoc """
+  GenServer process for managing batches of bulk jobs.
+  """
+
   use GenServer
   import Forcex.Bulk.Util
 
@@ -16,7 +20,7 @@ defmodule Forcex.Bulk.BatchWorker do
     job = Keyword.fetch!(state, :job)
     query = Keyword.fetch!(state, :query)
     handlers = Keyword.fetch!(state, :handlers)
-    interval = Keyword.get(state, :status_interval, 10000)
+    interval = Keyword.get(state, :status_interval, 10_000)
 
     batch = Forcex.Bulk.create_query_batch(query, job, client)
     notify_handlers({:batch_created, batch}, handlers)

--- a/lib/forcex/bulk/client.ex
+++ b/lib/forcex/bulk/client.ex
@@ -1,4 +1,8 @@
 defmodule Forcex.Bulk.Client do
+  @moduledoc """
+  Salesforce client for using the bulk API.
+  """
+
   defstruct session_id: nil,
             api_version: "43.0",
             endpoint: "https://login.salesforce.com",

--- a/lib/forcex/bulk/job_handler.ex
+++ b/lib/forcex/bulk/job_handler.ex
@@ -1,4 +1,8 @@
 defmodule Forcex.Bulk.JobHandler do
+  @moduledoc """
+  Functions for handling job state changes.
+  """
+
   @callback handle_job_created(map, any) :: {:noreply, any}
   @callback handle_job_closed(map, any) :: {:noreply, any}
   @callback handle_job_all_batches_complete(map, any) :: {:noreply, any}

--- a/lib/forcex/bulk/job_worker.ex
+++ b/lib/forcex/bulk/job_worker.ex
@@ -1,4 +1,8 @@
 defmodule Forcex.Bulk.JobWorker do
+  @moduledoc """
+  GenServer process for managing bulk jobs.
+  """
+
   use GenServer
   import Forcex.Bulk.Util
 
@@ -15,7 +19,7 @@ defmodule Forcex.Bulk.JobWorker do
     client = Keyword.fetch!(state, :client)
     sobject = Keyword.fetch!(state, :sobject)
     handlers = Keyword.get(state, :handlers, [])
-    interval = Keyword.get(state, :status_interval, 10000)
+    interval = Keyword.get(state, :status_interval, 10_000)
 
     job = Forcex.Bulk.create_query_job(sobject, client)
     notify_handlers({:job_created, job}, handlers)

--- a/lib/forcex/bulk/util.ex
+++ b/lib/forcex/bulk/util.ex
@@ -1,4 +1,8 @@
 defmodule Forcex.Bulk.Util do
+  @moduledoc """
+  Functions used across Bulk modules
+  """
+
   def notify_handlers(msg, handlers) do
     for handler <- handlers do
       spawn(fn -> send(handler, msg) end)

--- a/lib/forcex/util.ex
+++ b/lib/forcex/util.ex
@@ -1,4 +1,8 @@
 defmodule Forcex.Util do
+  @moduledoc """
+  Functions used across multiple modules.
+  """
+
   import Kernel, except: [to_string: 1]
 
   @mapping '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'

--- a/lib/mix/tasks/compile.forcex.ex
+++ b/lib/mix/tasks/compile.forcex.ex
@@ -1,3 +1,4 @@
+# credo:disable-for-this-file /Credo\.Check\.Refactor\./
 defmodule Mix.Tasks.Compile.Forcex do
   use Mix.Task
 

--- a/mix.exs
+++ b/mix.exs
@@ -66,6 +66,7 @@ defmodule Forcex.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
+      {:credo, "~> 1.6", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.2.0", only: [:dev, :test], runtime: false},
       {:httpoison, "~> 1.0"},
       {:exjsx, "< 5.0.0"},
@@ -97,8 +98,8 @@ defmodule Forcex.Mixfile do
         "compile --warnings-as-errors",
         "format --check-formatted",
         "deps.unlock --check-unused",
-        "test --warnings-as-errors"
-        # "credo"
+        "test --warnings-as-errors",
+        "credo"
       ]
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,8 @@
 %{
+  "bunt": {:hex, :bunt, "0.2.1", "e2d4792f7bc0ced7583ab54922808919518d0e57ee162901a16a1b6664ef3b14", [:mix], [], "hexpm", "a330bfb4245239787b15005e66ae6845c9cd524a288f0d141c148b02603777a5"},
   "certifi": {:hex, :certifi, "2.9.0", "6f2a475689dd47f19fb74334859d460a2dc4e3252a3324bd2111b8f0429e7e21", [:rebar3], [], "hexpm", "266da46bdb06d6c6d35fde799bcb28d36d985d424ad7c08b5bb48f5b5cdd4641"},
   "combine": {:hex, :combine, "0.10.0", "eff8224eeb56498a2af13011d142c5e7997a80c8f5b97c499f84c841032e429f", [:mix], [], "hexpm", "1b1dbc1790073076580d0d1d64e42eae2366583e7aecd455d1215b0d16f2451b"},
+  "credo": {:hex, :credo, "1.6.7", "323f5734350fd23a456f2688b9430e7d517afb313fbd38671b8a4449798a7854", [:mix], [{:bunt, "~> 0.2.1", [hex: :bunt, repo: "hexpm", optional: false]}, {:file_system, "~> 0.2.8", [hex: :file_system, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "41e110bfb007f7eda7f897c10bf019ceab9a0b269ce79f015d54b0dcf4fc7dd3"},
   "dialyxir": {:hex, :dialyxir, "1.2.0", "58344b3e87c2e7095304c81a9ae65cb68b613e28340690dfe1a5597fd08dec37", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "61072136427a851674cab81762be4dbeae7679f85b1272b6d25c3a839aff8463"},
   "earmark": {:hex, :earmark, "1.4.29", "02b75de0d54afb4f55712728c70f3014ff8a178eeb787b7c43a627e01ba2eb31", [:mix], [{:earmark_parser, "~> 1.4.27", [hex: :earmark_parser, repo: "hexpm", optional: false]}], "hexpm", "2fc2f5ffbeb235c553e70d0e5150c2535a7146abd23c92eb04de6cc47ea92b81"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.27", "755da957e2b980618ba3397d3f923004d85bac244818cf92544eaa38585cb3a8", [:mix], [], "hexpm", "8d02465c243ee96bdd655e7c9a91817a2a80223d63743545b2861023c4ff39ac"},


### PR DESCRIPTION
In order to improve the quality and consistency of the codebase, add the credo library and use it in `mix check` and in CI.