### PR TITLE
Allow filtering of sobjects

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,18 @@ Forcex.Client.default_config
 |> Forcex.Client.login(%Forcex.Client{endpoint: "https://test.salesforce.com", api_version: "34.0"})
 ```
 
+## SObject filtering
+
+If you only need to work with a subset of the SObjects to which you have access,
+you can save compile time by specifying only the SObjects that you want to be
+compiled:
+
+```elixir
+config :forcex, Forcex.Client,
+...
+  sobjects: ~w(Account User)
+```
+
 ## Testing
 
 Make sure dependencies are installed

--- a/lib/mix/tasks/compile.forcex.ex
+++ b/lib/mix/tasks/compile.forcex.ex
@@ -27,6 +27,7 @@ defmodule Mix.Tasks.Compile.Forcex do
       client
       |> Forcex.describe_global()
       |> Map.get(:sobjects)
+      |> filter_sobjects()
 
     for sobject <- sobjects do
       sobject
@@ -34,6 +35,15 @@ defmodule Mix.Tasks.Compile.Forcex do
       |> Code.compile_quoted()
     end
   end
+
+  defp filter_sobjects(all_sobjects), do: filter_sobjects(all_sobjects, config()[:sobjects])
+  defp filter_sobjects(all_sobjects, []), do: all_sobjects
+  defp filter_sobjects(all_sobjects, nil), do: all_sobjects
+
+  defp filter_sobjects(all_sobjects, selected_sobjects),
+    do: Enum.filter(all_sobjects, &sobject_selected?(&1, selected_sobjects))
+
+  defp sobject_selected?(sobject, selected_sobjects), do: sobject.name in selected_sobjects
 
   defp generate_module(sobject, client) do
     name = sobject.name
@@ -231,4 +241,6 @@ defmodule Mix.Tasks.Compile.Forcex do
   end
 
   defp docs_for_picklist_values(_), do: ""
+
+  defp config, do: Application.get_env(:forcex, Forcex.Client)
 end


### PR DESCRIPTION
In order to save compile time, allow configuration of an allow list of SObject modules to be compiled instead of always compiling all available modules.

Reproduced from https://github.com/jeffweiss/forcex/pull/28 , all credit to @mfb2 .